### PR TITLE
fix: fixed name shown when building package with Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
 
       # Use naersk's postUnpack to patch Cargo.toml
       package = naersklib.buildPackage {
+        name = "todo-tree";
         pname = "todo-tree";
         # Read version from cli/Cargo.toml since root is a workspace manifest
         version = (builtins.fromTOML (builtins.readFile ./cli/Cargo.toml)).package.version;


### PR DESCRIPTION
I don't know exactly why, but when building your system with todo-tree installed, it would show up as `rust-workspace` instead of `todo-tree`

Usually the `pname` it respected, but I suspect that because of the way the project is laid out, either naersk or the rust package was pulling the "name" of workspace.
Just adding the `name = "todo-tree"`
Below is the change when testing with my branch as the input.

<img width="241" height="115" alt="image" src="https://github.com/user-attachments/assets/e767b3f2-f444-444f-aecb-57c62ddb946b" />

PR should not affect anything else. Also includes formatting updates for readability.
Let me know what you think